### PR TITLE
Fixed FontAwesome

### DIFF
--- a/docs/FontAwesome.md
+++ b/docs/FontAwesome.md
@@ -64,7 +64,7 @@ Class reference
 
 #### stack methods
 
-* `static FA::s($foreground, $background, $options = [])` - Shortcut for stack()->icon()->on()
+* `static FA::si($foreground, $background, $options = [])` - Shortcut for stack()->icon()->on()
   * `$foreground` - `FA::icon` or the name of an icon in Font Awesome.
   * `$background` - `FA::icon` or the name of an icon in Font Awesome.
   * `$options` - additional attributes for the html tag.

--- a/helpers/base/FontAwesome.php
+++ b/helpers/base/FontAwesome.php
@@ -293,7 +293,7 @@ class FontAwesome extends \rmrevin\yii\fontawesome\FontAwesome
 	 * @param array $options
 	 * @return component\Icon
 	 */
-	public static function s($foreground, $background, $options = [])
+	public static function si($foreground, $background, $options = [])
 	{
 		return static::stack($options)->icon($foreground)->on($background);
 	}


### PR DESCRIPTION
Overriding the method `rmrevin\yii\fontawesome\FontAwesome::s()` in `p2made\yii2-p2y2-things\helpers\base\FontAwesome` causes error `Declaration of p2made\helpers\base\FontAwesome::s() should be compatible with rmrevin\yii\fontawesome\FontAwesome::s($options = Array)`